### PR TITLE
Add custom seo plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,8 @@ gem "jekyll", "~> 4.3.2"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 # gem "minima", "~> 2.5"
 gem "plainwhite"
-gem "jekyll-seo-tag"
-gem "jekyll-sitemap"
+gem "jekyll-seo-tag", github: "amassaad/jekyll-seo-tag"
+
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/amassaad/jekyll-seo-tag.git
+  revision: a6e9330112d1d622e0b11277df9e0257a3dea43c
+  specs:
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -35,10 +42,6 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
-    jekyll-seo-tag (2.8.0)
-      jekyll (>= 3.8, < 5.0)
-    jekyll-sitemap (1.4.0)
-      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.4.0)
@@ -76,8 +79,7 @@ DEPENDENCIES
   http_parser.rb (~> 0.6.0)
   jekyll (~> 4.3.2)
   jekyll-feed (~> 0.12)
-  jekyll-seo-tag
-  jekyll-sitemap
+  jekyll-seo-tag!
   plainwhite
   tzinfo (>= 1, < 3)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -31,7 +31,6 @@ url: "https://massaad.ca" # the base hostname & protocol for your site, e.g. htt
 theme: plainwhite
 plugins:
   - jekyll-feed
-  - jekyll-sitemap
   - jekyll-seo-tag
 
 plainwhite:

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,29 @@
+---
+layout: null
+---
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for post in site.posts %}
+    {% unless post.published == false %}    
+    <url>
+      <loc>{{ site.url }}{{ post.url | replace:'.html',''}}</loc>
+      <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+      <changefreq>monthly</changefreq>
+      <priority>0.5</priority>
+    </url>
+    {% endunless %}
+  {% endfor %}
+
+  {% assign pages = site.html_pages | where_exp: 'doc', 'doc.sitemap != false' | where_exp: 'doc','doc.url != "/404.html"' %}
+  {% for page in pages  %}
+  <url>
+    <loc>{{ site.url }}{{ page.url | remove: "index.html" | replace:'.html',''  }}</loc>
+    {% if page.date %}
+      <lastmod>{{ page.date | date_to_xmlschema }}</lastmod>
+    {% else %}
+      <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+    {% endif %}
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
Adds a sitemap.xml from a template vs gem. THis way I can strip the .html extension and avoid the problem with Cloudflare Pages redirecting away from this page always.

It also adds a custom SEO plugin to achieve the same with URL references. 